### PR TITLE
The default docroot is needed for now. Looks like a change is needed in ...

### DIFF
--- a/chef/roles/example.json
+++ b/chef/roles/example.json
@@ -8,7 +8,12 @@
    "drupal": {
       "sites": {
         "example": {
-          "active": true
+          "active": true,
+          "drupal": {
+            "settings": {
+              "docroot": ""
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
...the drupal recipe
