### PR TITLE
Updated vampd to point at version 4.0.6 of the drupal cookbook.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,7 +5,7 @@ cookbook 'build-essential', '~> 1.4.2'
 cookbook 'dmg', '~> 2.0.8'
 cookbook 'openssl', '~> 1.1.0'
 cookbook 'sudo', '~> 2.2.2'
-cookbook 'drupal', git: "https://github.com/vampd/drupal", tag: "4.0.5"
+cookbook 'drupal', git: "https://github.com/vampd/drupal", tag: "4.0.6"
 cookbook "drupal-nfs", git: "https://github.com/vampd/drupal-nfs", tag: "1.0.0"
 cookbook "drupal-frontend", git: "https://github.com/vampd/drupal-frontend", tag: "1.0.0"
 cookbook "drupal-solr", git: "https://github.com/vampd/drupal-solr", tag: "1.1.0"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES
   drupal
     git: https://github.com/vampd/drupal
     revision: 476551cb0702a7df6ae19a23c92642174be1ea47
-    tag: 4.0.5
+    tag: 4.0.6
   drupal-frontend
     git: https://github.com/vampd/drupal-frontend
     revision: d94e35bbc761f84a1fa11a981c324b12b08a55f8
@@ -36,7 +36,7 @@ GRAPH
     postgresql (>= 1.0.0)
     xfs (>= 0.0.0)
   dmg (2.0.8)
-  drupal (4.0.5)
+  drupal (4.0.6)
     apache2 (~> 1.8.14)
     apt (~> 2.3.0)
     database (~> 1.5.2)


### PR DESCRIPTION
Brings in script hooks:
https://github.com/vampd/drupal/wiki/Script-Hooks