### PR TITLE
Expanded README.md section on 'Mounting the assets through NFS'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,7 @@ And voila, you have a site installed!
 An NFS recipe comes preconfigured in vampd. This allows unix based systems, as well
 as some Windows versions to use NFS as a mount to access assets on the host.
 
-In your Vagrantfile, leave the following commented out:
-```
-  # for Vagrant-provided nfs support
-  #config.nfs.map_uid = 0
-  #config.nfs.map_gid = 0
-```
-
-Also leave the server.vm.synced_folder setting as "disabled: true":
+In your Vagrantfile, leave the server.vm.synced_folder setting as "disabled: true":
 
 ```
 server.vm.synced_folder 'assets', '/assets', disabled: true

--- a/README.md
+++ b/README.md
@@ -58,7 +58,22 @@ And voila, you have a site installed!
 An NFS recipe comes preconfigured in vampd. This allows unix based systems, as well
 as some Windows versions to use NFS as a mount to access assets on the host.
 
-On a OSX run:  `sudo mount -o resvport 192.168.50.5:/assets /assets`
+In your Vagrantfile, leave the following commented out:
+```
+  # for Vagrant-provided nfs support
+  #config.nfs.map_uid = 0
+  #config.nfs.map_gid = 0
+```
+
+Also leave the server.vm.synced_folder setting as "disabled: true":
+
+```
+server.vm.synced_folder 'assets', '/assets', disabled: true
+```
+
+Run 'vagrant up' from your machine (or 'vagrant provision' if your vbox is already running), then:
+
+On an OSX run:  `sudo mount -o resvport 192.168.50.5:/assets /assets`
 
 On linux run: `sudo mount 192.168.50.5:/assets /assets`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,9 +23,7 @@ require 'json'
  # data = JSON.parse(File.read("infrastructure/drupal_lamp.json"))
 
 Vagrant.configure("2") do |config|
-  # for Vagrant-provided nfs support
-  #config.nfs.map_uid = 0
-  #config.nfs.map_gid = 0
+
   working_dir = File.dirname(__FILE__) + "/"
   config.omnibus.chef_version = '11.16.2'
   config.berkshelf.enabled = true


### PR DESCRIPTION
In this pull request I'm recommending that users keep two lines commented out in Vagrantfile that are related to NFS sharing. Another approach would be to remove those lines altogether, since it doesn't appear as though we're configuring NFS that way any more.