### PR TITLE
Opens mysql server to outside connections when running the development environment.

### DIFF
--- a/chef/environments/development.json
+++ b/chef/environments/development.json
@@ -49,6 +49,7 @@
       "server_root_password": "root",
       "server_repl_password": "replication",
       "allow_remote_root": "true",
+      "bind_address": "0.0.0.0",
       "tunable": {
         "sync_binlog": "0",
         "innodb_flush_log_at_trx_commit": "0",


### PR DESCRIPTION
With this, developers can directly connect to mysql on their development boxes from their host machine.

eg.

    mysql -uroot -p -hdrupal.local