### PR TITLE
Two tweaks to NFS sharing section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation Instructions
 The install of vampd is not the easiest thing, but if you are familiar with the
 command line, should be fairly simple.
 
-First thing is first, you will need to install [vagrant](https://www.vagrantup.com/downloads.html),
+First things first, you will need to install [vagrant](https://www.vagrantup.com/downloads.html),
 [virtualbox](https://www.virtualbox.org/wiki/Downloads) and [ChefDK](https://downloads.getchef.com/chef-dk/).
 If you are on a Mac you will also need to install X-code from the App store (for Git).
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ server.vm.synced_folder 'assets', '/assets', disabled: true
 
 Run 'vagrant up' from your machine (or 'vagrant provision' if your vbox is already running), then:
 
-On an OSX run:  `sudo mount -o resvport 192.168.50.5:/assets /assets`
+1. At the command line, cd into the vampd root directory and mkdir assets
 
-On linux run: `sudo mount 192.168.50.5:/assets /assets`
+1. Mount the virtual machine's /assets directory to vampd/assets:
+
+	On an OSX run:  `sudo mount -o resvport 192.168.50.5:/assets assets`, or
+
+  On linux run: `sudo mount 192.168.50.5:/assets /assets`
 
 
 ##Mounting the assets through Samba

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Run 'vagrant up' from your machine (or 'vagrant provision' if your vbox is alrea
 
 	On an OSX run:  `sudo mount -o resvport 192.168.50.5:/assets assets`, or
 
-  On linux run: `sudo mount 192.168.50.5:/assets /assets`
+  On linux run: `sudo mount 192.168.50.5:/assets assets`
 
 
 ##Mounting the assets through Samba


### PR DESCRIPTION
I started from scratch with a new clone of vampd project and didn't realize that I had to create vampd/assets in order to mount the vbox's /assets folder to it. Also, corrected the mount commands.