### PR TITLE
Removed docroot from example, because it is no longer needed.

### DIFF
--- a/chef/roles/example.json
+++ b/chef/roles/example.json
@@ -11,11 +11,6 @@
           "active": true,
           "deploy": {
             "action": ["deploy", "install"]
-          },
-          "drupal": {
-            "settings": {
-              "docroot": ""
-            }
           }
         }
       }


### PR DESCRIPTION
With change in vampd/drupal#30, you no longer need to explicitly define `docroot`