### PR TITLE
vagrant synced_folders bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git clone https://github.com/vampd/vampd.git
 cd vampd
 vagrant plugin install vagrant-berkshelf
 vagrant plugin install vagrant-omnibus
+vagrant plugin install vagrant-triggers
 vagrant up
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,16 @@ Vagrant.configure("2") do |config|
   config.omnibus.chef_version = '11.16.2'
   config.berkshelf.enabled = true
   config.berkshelf.berksfile_path = working_dir + "Berksfile"
+    config.trigger.before [:reload, :up, :provision], stdout: true do
+    SYNCED_FOLDER = ".vagrant/machines/drupaldev/virtualbox/synced_folders"
+    info "Trying to delete folder #{SYNCED_FOLDER}"
+    begin
+      File.delete(SYNCED_FOLDER)
+    rescue StandardError => e
+      warn "Could not delete folder #{SYNCED_FOLDER}."
+      warn e.inspect
+    end
+  end
   config.vm.define :drupaldev do |server|
     server.ssh.forward_agent = true
     server.vm.box = "precise64current"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
   config.omnibus.chef_version = '11.16.2'
   config.berkshelf.enabled = true
   config.berkshelf.berksfile_path = working_dir + "Berksfile"
-    config.trigger.before [:reload, :up, :provision], stdout: true do
+  config.trigger.before [:reload, :up, :provision], stdout: true do
     SYNCED_FOLDER = ".vagrant/machines/drupaldev/virtualbox/synced_folders"
     info "Trying to delete folder #{SYNCED_FOLDER}"
     begin


### PR DESCRIPTION
I think this is a bug in the latest vagrant (1.7.2) version, but I get the error as outlined in this thread: https://github.com/mitchellh/vagrant/issues/5199#issuecomment-98874689. Basically an initial <code>vagrant up</code> spins up without any issues, then if I <code>vagrant halt</code>, <code>vagrant up --provision</code> it'll produce an error relating to the file '.vagrant/machines/drupaldev/virtualbox/synced_folders'. Removing this file will fix this issue and I added the proper code to the vagrantfile to do this automatically. I'm sure the next version of vagrant will fix this, but I thought this fix was helpful for me and could help relieve others frustration. 

I hardcoded the 'drupaldev' and 'virtualbox' parts of the synced_folder path, but if you know of any variables that can replace these that would be great. I'm new to ruby and couldn't quite track this down.
